### PR TITLE
Add sample Flutter stock app

### DIFF
--- a/lib/bloc/stock_bloc.dart
+++ b/lib/bloc/stock_bloc.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+
+import '../model/stock.dart';
+import '../repository/stock_repository.dart';
+
+abstract class StockEvent {}
+
+class FetchStocks extends StockEvent {}
+
+class StockVisibilityChanged extends StockEvent {
+  final String id;
+  final bool visible;
+
+  StockVisibilityChanged(this.id, this.visible);
+}
+
+class _StocksUpdated extends StockEvent {
+  final List<Stock> stocks;
+
+  _StocksUpdated(this.stocks);
+}
+
+class StockState {
+  final List<Stock> stocks;
+
+  const StockState(this.stocks);
+}
+
+class StockBloc extends Bloc<StockEvent, StockState> {
+  final StockRepository _repository;
+  StreamSubscription<List<Stock>>? _subscription;
+
+  StockBloc(this._repository) : super(const StockState([])) {
+    on<FetchStocks>(_onFetch);
+    on<StockVisibilityChanged>(_onVisibilityChanged);
+    on<_StocksUpdated>(_onStocksUpdated);
+  }
+
+  Future<void> _onFetch(FetchStocks event, Emitter<StockState> emit) async {
+    final stocks = await _repository.fetchStocks();
+    emit(StockState(List.of(stocks)));
+    _subscription?.cancel();
+    _subscription = _repository.subscribe((list) => add(_StocksUpdated(list)));
+  }
+
+  void _onVisibilityChanged(
+      StockVisibilityChanged event, Emitter<StockState> emit) {
+    if (event.visible) {
+      _repository.addVisible(event.id);
+    } else {
+      _repository.removeVisible(event.id);
+    }
+  }
+
+  void _onStocksUpdated(_StocksUpdated event, Emitter<StockState> emit) {
+    emit(StockState(List.of(event.stocks)));
+  }
+
+  @override
+  Future<void> close() {
+    _subscription?.cancel();
+    return super.close();
+  }
+}

--- a/lib/data/mock_websocket.dart
+++ b/lib/data/mock_websocket.dart
@@ -1,0 +1,33 @@
+import 'dart:async';
+import 'dart:math';
+
+import '../model/stock.dart';
+
+class MockWebSocket {
+  final List<Stock> _stocks;
+  final StreamController<Stock> _controller = StreamController.broadcast();
+  final Random _random = Random();
+  Timer? _timer;
+
+  MockWebSocket(this._stocks) {
+    _timer = Timer.periodic(const Duration(seconds: 5), (_) => _updateRandom());
+  }
+
+  Stream<Stock> get stream => _controller.stream;
+
+  List<Stock> get stocks => List.unmodifiable(_stocks);
+
+  void dispose() {
+    _timer?.cancel();
+    _controller.close();
+  }
+
+  void _updateRandom() {
+    if (_stocks.isEmpty) return;
+    final index = _random.nextInt(_stocks.length);
+    final change = _random.nextDouble() * 10 - 5;
+    final stock = _stocks[index];
+    stock.price += change;
+    _controller.add(stock);
+  }
+}

--- a/lib/data/stock_data_source.dart
+++ b/lib/data/stock_data_source.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import '../model/stock.dart';
+import 'mock_websocket.dart';
+
+class StockDataSource {
+  final MockWebSocket _socket;
+  final StreamController<List<Stock>> _controller =
+      StreamController.broadcast();
+  final List<Stock> _stocks;
+  final Set<String> _visibleIds = {};
+  late final StreamSubscription<Stock> _sub;
+
+  StockDataSource(this._socket) : _stocks = List.of(_socket.stocks) {
+    _controller.add(List.of(_stocks));
+    _sub = _socket.stream.listen(_onUpdate);
+  }
+
+  Stream<List<Stock>> get stream => _controller.stream;
+
+  Future<List<Stock>> fetchStocks() async {
+    return List.of(_stocks);
+  }
+
+  void _onUpdate(Stock stock) {
+    if (_visibleIds.contains(stock.id)) {
+      final index = _stocks.indexWhere((e) => e.id == stock.id);
+      if (index != -1) {
+        _stocks[index] = stock;
+        _controller.add(List.of(_stocks));
+      }
+    }
+  }
+
+  void updateVisibility(Set<String> ids) {
+    _visibleIds
+      ..clear()
+      ..addAll(ids);
+  }
+
+  void dispose() {
+    _sub.cancel();
+    _controller.close();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'bloc/stock_bloc.dart';
+import 'data/mock_websocket.dart';
+import 'data/stock_data_source.dart';
+import 'model/stock.dart';
+import 'repository/stock_repository.dart';
+import 'ui/stock_page.dart';
+
+void main() {
+  final stocks = List.generate(
+    20,
+    (i) => Stock(id: '$i', name: 'Stock $i', price: 100 + i.toDouble()),
+  );
+  final socket = MockWebSocket(stocks);
+  final dataSource = StockDataSource(socket);
+  final repository = StockRepository(dataSource);
+
+  runApp(StockApp(repository: repository));
+}
+
+class StockApp extends StatelessWidget {
+  final StockRepository repository;
+
+  const StockApp({Key? key, required this.repository}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Stock Manager',
+      home: BlocProvider(
+        create: (_) => StockBloc(repository),
+        child: const StockPage(),
+      ),
+    );
+  }
+}

--- a/lib/model/stock.dart
+++ b/lib/model/stock.dart
@@ -1,0 +1,15 @@
+class Stock {
+  final String id;
+  final String name;
+  double price;
+
+  Stock({required this.id, required this.name, required this.price});
+
+  Stock copyWith({double? price}) {
+    return Stock(
+      id: id,
+      name: name,
+      price: price ?? this.price,
+    );
+  }
+}

--- a/lib/repository/stock_repository.dart
+++ b/lib/repository/stock_repository.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import '../model/stock.dart';
+import '../data/stock_data_source.dart';
+
+class StockRepository {
+  final StockDataSource _dataSource;
+  final Set<String> _visibleSet = {};
+
+  StockRepository(this._dataSource);
+
+  Future<List<Stock>> fetchStocks() => _dataSource.fetchStocks();
+
+  StreamSubscription<List<Stock>> subscribe(void Function(List<Stock>) callback) {
+    return _dataSource.stream.listen(callback);
+  }
+
+  void addVisible(String id) {
+    _visibleSet.add(id);
+    _dataSource.updateVisibility(_visibleSet);
+  }
+
+  void removeVisible(String id) {
+    _visibleSet.remove(id);
+    _dataSource.updateVisibility(_visibleSet);
+  }
+}

--- a/lib/ui/stock_page.dart
+++ b/lib/ui/stock_page.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:visibility_detector/visibility_detector.dart';
+import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+
+import '../bloc/stock_bloc.dart';
+import '../model/stock.dart';
+
+class StockPage extends StatefulWidget {
+  const StockPage({Key? key}) : super(key: key);
+
+  @override
+  State<StockPage> createState() => _StockPageState();
+}
+
+class _StockPageState extends State<StockPage> {
+  final PagingController<int, Stock> _pagingController =
+      PagingController(firstPageKey: 0);
+
+  @override
+  void initState() {
+    super.initState();
+    _pagingController.addPageRequestListener((pageKey) {
+      context.read<StockBloc>().add(FetchStocks());
+    });
+  }
+
+  @override
+  void dispose() {
+    _pagingController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Stocks')),
+      body: BlocListener<StockBloc, StockState>(
+        listener: (context, state) {
+          _pagingController.itemList = List.of(state.stocks);
+        },
+        child: PagedListView<int, Stock>(
+          pagingController: _pagingController,
+          builderDelegate: PagedChildBuilderDelegate<Stock>(
+            itemBuilder: (context, stock, index) => VisibilityDetector(
+              key: Key('stock_${stock.id}'),
+              onVisibilityChanged: (info) {
+                context.read<StockBloc>().add(
+                      StockVisibilityChanged(
+                        stock.id,
+                        info.visibleFraction > 0,
+                      ),
+                    );
+              },
+              child: ListTile(
+                title: Text(stock.name),
+                trailing: Text(stock.price.toStringAsFixed(2)),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,25 @@
+name: stock_manager
+description: Sample stock flutter application.
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_bloc: ^8.1.2
+  visibility_detector: ^0.2.2
+  infinite_scroll_pagination: ^3.2.0
+
+  # The following adds the Cupertino Icons font to your application.
+  # Use with the CupertinoIcons class for iOS style icons.
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- implement a simple Flutter app showing stocks
- add mock websocket and datasource layers
- create repository, bloc and UI using visibility detector
- wire up packages via `pubspec.yaml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bebc07ac88320b7afaaa21558aa60